### PR TITLE
Fix codon translation bug

### DIFF
--- a/frontend/bonsai_app/custom_filters.py
+++ b/frontend/bonsai_app/custom_filters.py
@@ -226,8 +226,8 @@ def nt_to_aa(nt_seq: str) -> str:
         "GGA": "G",
         "GGG": "G",
     }
-    stop_codons = (["TAA", "TAG", "TGA"],)
-    start_codons = (["TTG", "CTG", "ATT", "ATC", "ATA", "ATG", "GTG"],)
+    stop_codons = ["TAA", "TAG", "TGA"]
+    start_codons = ["TTG", "CTG", "ATT", "ATC", "ATA", "ATG", "GTG"]
     aa_seq = ""
     for pos in range(0, len(nt_seq), 3):
         codon = nt_seq[pos : pos + 3].upper()


### PR DESCRIPTION
## Summary
- fix `nt_to_aa` translation filter so START/STOP codons are detected properly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas, pymongo, flask_login, minhash_service)*

------
https://chatgpt.com/codex/tasks/task_e_68496030dcbc8322990512d242018fd3